### PR TITLE
Fix the oneblog link url in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bdougie.live
 This blog powered by GitHub issues
 
-A location where individuals can come together and watch a few people stream their code. This repo is powered by [oneblog](https://github.com/ongraph/oneblog).
+A location where individuals can come together and watch a few people stream their code. This repo is powered by [oneblog](https://github.com/onegraph/oneblog).
 
 Schedule for streams can be found at [twitch.tv/bdougieYO](https://www.twitch.tv/bdougieyo).
 


### PR DESCRIPTION
Hey there 👋🏼 

I noticed a typo in the oneblog URL that would give a 404. It was pointing to the wrong GitHub account/org. I thought it was simple enough to make this PR. Hope that's ok.