### PR TITLE
Update discord-notification.yml

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -43,7 +43,7 @@ jobs:
         id: data
         shell: bash
         run: |
-          ISSUE_TITLE="$(jq '.data.title' result.json)"
+          ISSUE_TITLE="$(jq '.title' result.json)"
           echo $ISSUE_TITLE
           
           echo ::set-output name=title::${ISSUE_TITLE}


### PR DESCRIPTION
# What is this?

So, looks like the notification was broken. I fixed it here. 

before:

<img width="627" alt="Screen Shot 2021-04-09 at 4 11 40 PM" src="https://user-images.githubusercontent.com/5713670/114235604-6a9b6600-994e-11eb-8bbb-5585d53f22cc.png">

after: 

<img width="614" alt="Screen Shot 2021-04-09 at 4 11 35 PM" src="https://user-images.githubusercontent.com/5713670/114235545-57889600-994e-11eb-9320-536da4b7eed5.png">

